### PR TITLE
Changing what command to run for the python prerequisites

### DIFF
--- a/examples/python/prerequisites.md
+++ b/examples/python/prerequisites.md
@@ -1,7 +1,7 @@
 # Prerequisites for running the Python examples
 To run the Python SSE plugin examples, you need __Python__ version 3.4 or higher along with a few _python libraries_.
 
-Anaconda is a Python distribution pre-bundled with multiple extra libraries, some of the ones used in the examples here. An installer can be downloaded from the [Anaconda webpage](https://www.continuum.io/downloads). For a leaner installation the default installer can be found on the webpage of the [Python Software Foundation](https://www.python.org/downloads/).
+Anaconda is a Python distribution pre-bundled with multiple extra libraries. An installer can be downloaded from the [Anaconda webpage](https://www.continuum.io/downloads). For a leaner installation the default installer can be found on the webpage of the [Python Software Foundation](https://www.python.org/downloads/).
 
 The following _python libraries_ are needed for the specified SSE plugins.
 
@@ -15,4 +15,4 @@ The simplest way to acquire the libraries is to use the Python package manager `
 
 __Note__
 --------
-The `requirements.txt` specifies the dependencies and the recommended versions. If you choose to install the libraries manually yourself make sure to take a _grpcio_ version that is compatible as there might be breaking changes between versions.
+The `requirements.txt` specifies the dependencies and the recommended versions. If you choose to install the libraries manually make sure to take a _grpcio_ version that is compatible as there might be breaking changes between versions. If you need to have a different version installed for another Python project consider using [virtualenv](https://virtualenv.pypa.io/en/stable/).

--- a/examples/python/prerequisites.md
+++ b/examples/python/prerequisites.md
@@ -1,9 +1,9 @@
 # Prerequisites for running the Python examples
 To run the Python SSE plugin examples, you need __Python__ version 3.4 or higher along with a few _python libraries_.
 
-Anaconda is a Python distribution pre-bundled with multiple extra libraries. An installer can be downloaded from the [Anaconda webpage](https://www.continuum.io/downloads). For a leaner installation the default installer can be found on the webpage of the [Python Software Foundation](https://www.python.org/downloads/).
+Anaconda is a Python distribution pre-bundled with multiple extra libraries. An installer can be downloaded from the [Anaconda webpage](https://www.continuum.io/downloads). For a leaner installation, the default installer can be found on the webpage of the [Python Software Foundation](https://www.python.org/downloads/).
 
-The following _python libraries_ are needed for the specified SSE plugins.
+The following _python libraries_ are needed for the specified SSE plugins:
 
 | __Name__ | __SSE plugin(s)__ |
 | ----- | ----- |
@@ -11,8 +11,12 @@ The following _python libraries_ are needed for the specified SSE plugins.
 | __numpy__ | _FullScriptSupport_ and _FullScriptSupport_Pandas_ |
 | __pandas__ | _FullScriptSupport_Pandas_ |
 
-The simplest way to acquire the libraries is to use the Python package manager `pip`. Open up a command prompt (command line), navigate to the `examples\python\` folder and run the command `python -m pip install -r requirements.txt`. If Python is correctly set up on the machines all the dependencies should get installed.
+The simplest way to acquire the libraries is to use the Python package manager `pip`. Open up a command prompt, navigate to the `examples\python\` folder, and then run the command:
+
+ `python -m pip install -r requirements.txt`.
+
+  If Python is correctly set up on the machines all the dependencies should get installed.
 
 __Note__
 --------
-The `requirements.txt` specifies the dependencies and the recommended versions. If you choose to install the libraries manually make sure to take a _grpcio_ version that is compatible as there might be breaking changes between versions. If you need to have a different version installed for another Python project consider using [virtualenv](https://virtualenv.pypa.io/en/stable/).
+Dependencies and recommended versions are specified in `requirements.txt`. If you install the libraries manually, make sure to take a _grpcio_ version that is compatible as there might be breaking changes between versions. If you need to have a different version installed for another Python project, consider using [virtualenv](https://virtualenv.pypa.io/en/stable/).

--- a/examples/python/prerequisites.md
+++ b/examples/python/prerequisites.md
@@ -1,10 +1,18 @@
 # Prerequisites for running the Python examples
-To run the Python SSE plugin examples, you need __Python__ version 3.4 or higher. You can find links for installing Anaconda (a Python distribution including common libraries and packages) on the [Anaconda webpage](https://www.continuum.io/downloads). For Python without any libraries, see the [Python webpage](https://www.python.org/downloads/).
+To run the Python SSE plugin examples, you need __Python__ version 3.4 or higher along with a few _python libraries_.
+
+Anaconda is a Python distribution pre-bundled with multiple extra libraries, some of the ones used in the examples here. An installer can be downloaded from the [Anaconda webpage](https://www.continuum.io/downloads). For a leaner installation the default installer can be found on the webpage of the [Python Software Foundation](https://www.python.org/downloads/).
 
 The following _python libraries_ are needed for the specified SSE plugins.
 
-| __Name__ | __SSE plugin(s)__ | __Comments__ |  
-| ----- | ----- | ----- |
-|  __grpcio__ |all examples | Install the package using pip: `$ python -m pip install grpcio` |
-| __numpy__ |_FullScriptSupport_ and _FullScriptSupport_Pandas_ | Included in most python distributions, including Anaconda. If needed, install using pip: `$ python -m pip install numpy`. |
-| __pandas__ |_FullScriptSupport_Pandas_ |  Included in most python distributions, including Anaconda. If needed, install using pip: `$ python -m pip install pandas`. |
+| __Name__ | __SSE plugin(s)__ |
+| ----- | ----- |
+|  __grpcio__ |all examples |
+| __numpy__ | _FullScriptSupport_ and _FullScriptSupport_Pandas_ |
+| __pandas__ | _FullScriptSupport_Pandas_ |
+
+The simplest way to acquire the libraries is to use the Python package manager `pip`. Open up a command prompt (command line), navigate to the `examples\python\` folder and run the command `python -m pip install -r requirements.txt`. If Python is correctly set up on the machines all the dependencies should get installed.
+
+__Note__
+--------
+The `requirements.txt` specifies the dependencies and the recommended versions. If you choose to install the libraries manually yourself make sure to take a _grpcio_ version that is compatible as there might be breaking changes between versions.


### PR DESCRIPTION
The commands we listed to help people set up the python
environment to run the examples did not specify version numbers

After this PR the recommended command uses the requirements.txt
file.