### PR TITLE
Replace deprecated append method with concat 

### DIFF
--- a/examples/python/fullscriptsupport_pandas/scripteval.py
+++ b/examples/python/fullscriptsupport_pandas/scripteval.py
@@ -44,7 +44,7 @@ class ScriptEval:
                 for row in request_rows.rows:
                     # Retrieve parameters and append to data frame
                     params, dual_exist = self.get_arguments(context, arg_types, row.duals, header)
-                    q = q.append(params, ignore_index=True)
+                    q = pandas.append([q, params], ignore_index=True)
 
             # Rename columns based on arg names in header
             arg_names = [param.name for param in header.params]

--- a/examples/python/fullscriptsupport_pandas/scripteval.py
+++ b/examples/python/fullscriptsupport_pandas/scripteval.py
@@ -44,7 +44,7 @@ class ScriptEval:
                 for row in request_rows.rows:
                     # Retrieve parameters and append to data frame
                     params, dual_exist = self.get_arguments(context, arg_types, row.duals, header)
-                    q = pandas.append([q, params], ignore_index=True)
+                    q = pandas.concat([q, params], ignore_index=True)
 
             # Rename columns based on arg names in header
             arg_names = [param.name for param in header.params]


### PR DESCRIPTION
Replaced the deprecated and recently removed `Dataframe.append()` method with the recommended `Pandas.concat()`. `Dataframe.append()` has been deprecated for a while and was removed in the most recent Pandas 2.0.0 release. See Pandas issue [here](https://github.com/pandas-dev/pandas/issues/35407).

There was not an existing issue for this, let me know if I should make one first for tracking purposes.

### Status
```
[ ] Under development
[X] Waiting for code review
[ ] Waiting for merge
```
### Information
```
[ ] Contains breaking changes
[ ] Contains new API(s)
[ ] Contains documentation
[ ] Contains test
[ ] Contains examples
```
### To-do list
_No todos_
